### PR TITLE
new tls option for mysqlconfig_user

### DIFF
--- a/hiera-configs/defaults/mysqlconfig_user.yaml
+++ b/hiera-configs/defaults/mysqlconfig_user.yaml
@@ -6,4 +6,7 @@ mysqlconfig_user_ensure:
     value: 'present'
 mysqlconfig_user_password_hash:
     value:
+mysqlconfig_user_tls_options:
+    value: 'NONE'
+
 

--- a/hiera-configs/puppetfile_dictionary_v4.yaml
+++ b/hiera-configs/puppetfile_dictionary_v4.yaml
@@ -391,7 +391,7 @@ mysql:
     repo: 'https://github.com/Adaptavist/puppet-mysql.git'
     ref_type: 'tag'
     repo_type: 'git'
-    ref_value: '3.7.0a'
+    ref_value: '3.7.0b'
 
 xinetd: 
     name: "puppetlabs/xinetd"

--- a/hiera-configs/templates/mysqlconfig_user.yaml
+++ b/hiera-configs/templates/mysqlconfig_user.yaml
@@ -21,4 +21,7 @@ mysqlconfig::users:
     "%{::mysqlconfig_user_name}":
         ensure: "%{::mysqlconfig_user_ensure}"
         password_hash: "%{::mysqlconfig_user_password_hash}"
+        tls_options: 
+          - "%{::mysqlconfig_user_tls_options}"
+
 


### PR DESCRIPTION
this is to allow for the use of TLS when configuring new mysql users

Ensure 'ssl_type' Is Set to 'ANY', 'X509', or 'SPECIFIED' for All Remote Users
-this sets require ssl for the user