### PR TITLE
added ability to specify admin password

### DIFF
--- a/hiera-configs/defaults/mysql_secure.yaml
+++ b/hiera-configs/defaults/mysql_secure.yaml
@@ -40,3 +40,7 @@ mysql_secure_users:
     value: 'true'
     description: 'Activate to enable remove_default_accounts'
     type: 'boolean'
+mysql_admin_password:
+    value: '~'
+    description: 'the mysql administrator password (not root but administrator)'
+    type: 'nilable'

--- a/hiera-configs/templates/mysql_secure.yaml
+++ b/hiera-configs/templates/mysql_secure.yaml
@@ -62,3 +62,4 @@ database::conf:
     name:     "%{::database_db_database_name}"
 
 mysqlconfig::remove_default_accounts: "%{::mysql_secure_users}"
+mysqlconfig::admin_password: "%{::mysql_admin_password}"


### PR DESCRIPTION
added the optional ability to specify mysql admin password (admin user exists for debian and is created for rhel) by default the PW is randomly generated but it is sometimes preferable to specify one